### PR TITLE
Add tick timer reference to fix timer initialization error

### DIFF
--- a/arch/arm/dts/am335x-osd335x-common.dtsi
+++ b/arch/arm/dts/am335x-osd335x-common.dtsi
@@ -16,6 +16,10 @@
 		device_type = "memory";
 		reg = <0x80000000 0x20000000>; /* 512 MB */
 	};
+
+  chosen {
+    tick-timer = &timer2;
+  };
 };
 
 &cpu0_opp_table {


### PR DESCRIPTION
See [oresat-linux/#58](https://github.com/oresat/oresat-linux/issues/58) for context.